### PR TITLE
Fix wrong Turkish translation

### DIFF
--- a/app/assets/i18n/tr.json
+++ b/app/assets/i18n/tr.json
@@ -2,9 +2,9 @@
     "home": {
         "hello": "Merhaba!",
         "hello_name": "Merhaba {name}!",
-        "last_run": "Son çalıştırmanızın adı ",
+        "last_run": "Son denemenizin adı ",
         "last_run_with": "Your last run with ",
-        "run": "Çalışmanızın adı ",
+        "run": "Denemenizin adı ",
         "run_with": "Your run with ",
         "and": " ve ",
         "named": "called"


### PR DESCRIPTION
Mentioned on Discord about this before realizing I can just make a PR.

Anyway, "Çalıştırma" is not used in this context. In this context there is no way we can translate "Run" into Turkish and the best fitting translation is the Turkish word for "Attempt".

"Çalıştırma" is used for sentences such as "Running a car."
---

Additionally, to translate the `last_run_with` and `run_with` lines, while it would be necceseary to add extra variables for player names to properly translate these, there is a way they can be translated into Turkish with the current format. It would sound like "Your run with these players [player names]".

If you approve this translation I will add it into this PR.