### PR TITLE
feat: release version 1.0.0 and update installer

### DIFF
--- a/app/installers/installer.iss
+++ b/app/installers/installer.iss
@@ -2,8 +2,8 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Profit Taker Analytics"
-#define MyAppVersion "0.9.7"
-#define MyAppPublisher "Basi"
+#define MyAppVersion "1.0.0"
+#define MyAppPublisher "Enrique Rodrigues (Basi)"
 #define MyAppURL "https://basi.is-a.dev/pta"
 #define MyAppExeName "profit_taker_analyzer.exe"
 
@@ -24,7 +24,7 @@ DisableProgramGroupPage=yes
 LicenseFile=C:\Users\basi\Documents\GitHub\portfolio\ptdocssource\docs\docs\eula.md
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
-OutputBaseFilename=pta_0.9.7
+OutputBaseFilename=pta_1.0.0
 Compression=lzma2/max
 WizardStyle=modern
 
@@ -37,18 +37,7 @@ Name: "russian"; MessagesFile: "compiler:Languages\Russian.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "C:\Users\basi\Documents\GitHub\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\Users\basi\Documents\GitHub\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\bin\*"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "C:\Users\basi\Documents\GitHub\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\data\*"; DestDir: "{app}\data"; Flags: ignoreversion recursesubdirs createallsubdirs
-; Source: "C:\Github\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\update\*"; DestDir: "{app}\update"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "C:\Users\basi\Documents\GitHub\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\flutter_windows.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\Users\basi\Documents\GitHub\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\irondash_engine_context_plugin.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\Users\basi\Documents\GitHub\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\screen_retriever_plugin.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\Users\basi\Documents\GitHub\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\super_native_extensions.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\Users\basi\Documents\GitHub\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\super_native_extensions_plugin.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\Users\basi\Documents\GitHub\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\url_launcher_windows_plugin.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\Users\basi\Documents\GitHub\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\window_manager_plugin.dll"; DestDir: "{app}"; Flags: ignoreversion
-; NOTE: Don't use "Flags: ignoreversion" on any shared system files
+Source: "C:\Users\basi\Documents\GitHub\Profit-Taker-Analytics\app\build\windows\x64\runner\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Dirs]
 Name: {app}\storage
@@ -60,3 +49,7 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 
+[Registry]
+Root: HKCR; Subkey: "pta"; ValueType: string; ValueName: ""; ValueData: "URL:PTA Protocol"; Flags: uninsdeletekey
+Root: HKCR; Subkey: "pta"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""; Flags: uninsdeletevalue
+Root: HKCR; Subkey: "pta\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: """{app}\\{#MyAppExeName}"" ""%1"""; Flags: uninsdeletekey

--- a/app/lib/constants/app/app_constants.dart
+++ b/app/lib/constants/app/app_constants.dart
@@ -1,7 +1,7 @@
 /// A class to hold constant values for the app, including asset paths for icons.
 class AppConstants {
   // Main app constants
-  static const String version = '1.0.0-beta.6';
+  static const String version = '1.0.0';
   static const String appName = "Profit Taker Analytics";
   static const String assets = 'assets/icons';
   static const String databaseFolder = 'database';

--- a/app/lib/screens/home/widgets/onboarding_popup.dart
+++ b/app/lib/screens/home/widgets/onboarding_popup.dart
@@ -3,7 +3,6 @@ import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:profit_taker_analyzer/constants/preferences/shared_prefs_keys.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-// TODO: Ensure this is up to date once app is ready for v1.0.0
 class OnboardingPopup extends StatefulWidget {
   final VoidCallback onFinish;
 

--- a/app/lib/utils/initialization/initialize_window_manager.dart
+++ b/app/lib/utils/initialization/initialize_window_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:profit_taker_analyzer/constants/app/app_constants.dart';
 import 'package:profit_taker_analyzer/constants/layout/layout_constants.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -13,6 +14,7 @@ import 'package:window_manager/window_manager.dart';
 /// A [Future<void>] that completes once the window manager is initialized and the window is shown and focused.
 Future<void> initializeWindowManager() async {
   await windowManager.ensureInitialized();
+  await windowManager.setTitle(AppConstants.appName);
   WindowOptions windowOptions = const WindowOptions(
     size: Size(LayoutConstants.startingWidth, LayoutConstants.startingHeight),
     minimumSize:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -353,10 +353,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.19.0"
   irondash_engine_context:
     dependency: transitive
     description:
@@ -393,10 +393,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -957,10 +957,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:
@@ -989,10 +989,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
+      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.0"
+    version: "5.13.0"
   win32_registry:
     dependency: transitive
     description:
@@ -1050,5 +1050,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.29.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: profit_taker_analyzer
 description: "Warframe Profit Taker analysis app."
 publish_to: "none"
-version: 1.0.0-beta.6
+version: 1.0.0
 
 environment:
   sdk: ">=3.2.0-199.0.dev <4.0.0"
@@ -40,7 +40,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   # Used for DateTime functions
-  intl: 0.20.2
+  intl: 0.19.0
   # To be able to get path from File objects
   path: any
   # Table for run storage screen


### PR DESCRIPTION
Bump app version to 1.0.0 in constants and pubspec, update installer script for new version and publisher, simplify file inclusion, and add registry entries for PTA protocol. Also set window title on initialization and remove outdated onboarding popup comment. Downgrade several dependencies in pubspec and lock file to match new requirements.